### PR TITLE
[Fix] flags are also choices - update qgsettings.cpp

### DIFF
--- a/src/gsettings/qgsettings.cpp
+++ b/src/gsettings/qgsettings.cpp
@@ -204,7 +204,7 @@ QVariantList QGSettings::choices(const QString &key) const
     GVariant *value;
     g_variant_get(range, "(&sv)", &type, &value);
 
-    if (g_str_equal(type, "enum")) {
+    if (g_str_equal(type, "enum") || g_str_equal(type, "flags")) {
         GVariantIter iter;
         g_variant_iter_init(&iter, value);
 

--- a/src/imports/gsettings/qmlgsettingsschema.cpp
+++ b/src/imports/gsettings/qmlgsettingsschema.cpp
@@ -52,6 +52,7 @@ void QmlGSettingsSchema::setId(const QString &id)
     }
 
     m_schemaId = id;
+    emit idChanged();
 }
 
 QString QmlGSettingsSchema::path() const
@@ -67,6 +68,7 @@ void QmlGSettingsSchema::setPath(const QString &path)
     }
 
     m_path = path;
+    emit pathChanged();
 }
 
 QStringList QmlGSettingsSchema::keys() const

--- a/src/imports/gsettings/qmlgsettingsschema.h
+++ b/src/imports/gsettings/qmlgsettingsschema.h
@@ -33,8 +33,8 @@ class QmlGSettingsSchema : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(bool valid READ isValid NOTIFY validChanged)
-    Q_PROPERTY(QString id MEMBER m_schemaId WRITE setId NOTIFY idChanged)
-    Q_PROPERTY(QString path MEMBER m_path WRITE setPath NOTIFY pathChanged)
+    Q_PROPERTY(QString id READ id WRITE setId NOTIFY idChanged)
+    Q_PROPERTY(QString path READ path WRITE setPath NOTIFY pathChanged)
     Q_PROPERTY(QStringList keys READ keys NOTIFY keysChanged)
 public:
     QmlGSettingsSchema(QObject *parent = 0);

--- a/src/imports/gsettings/qmlgsettingsschema.h
+++ b/src/imports/gsettings/qmlgsettingsschema.h
@@ -33,8 +33,8 @@ class QmlGSettingsSchema : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(bool valid READ isValid NOTIFY validChanged)
-    Q_PROPERTY(QString id READ id WRITE setId)
-    Q_PROPERTY(QString path READ path WRITE setPath)
+    Q_PROPERTY(QString id MEMBER m_schemaId WRITE setId NOTIFY idChanged)
+    Q_PROPERTY(QString path MEMBER m_path WRITE setPath NOTIFY pathChanged)
     Q_PROPERTY(QStringList keys READ keys NOTIFY keysChanged)
 public:
     QmlGSettingsSchema(QObject *parent = 0);
@@ -53,7 +53,8 @@ public:
 Q_SIGNALS:
     void validChanged();
     void keysChanged();
-
+    void idChanged();
+    void pathChanged();
 private:
     bool m_valid;
     QString m_schemaId;


### PR DESCRIPTION
[Fix] flags are also choices - update qgsettings.cpp
[Fix] qml complains about no NOTIFY signal on schema id and path
        they can't change but it will complain if you reference them by
        `Label {text: gsettings.schema.id }`
        commit silences the warning

EDIT: 
FIX 1: Flags are choices according to glib, they were not treated as such and choices() did not return their values

FIX 2: Referencing to schema id or path results in no notify errors. Add notify signal.